### PR TITLE
Investigate scoring

### DIFF
--- a/SpeedReading/Script/Application.js
+++ b/SpeedReading/Script/Application.js
@@ -309,7 +309,7 @@ addAsmPlans();
 
 function TestComplete_Callback() {
     perf.StopTest();
-    var message = "                 Browser Score                   " + Math.floor(((perf.testDuration - totalCallbackDuration) / 1000)) + " Seconds";
+    var message = "                 Browser Score                   " + Math.floor((perf.testDuration / 1000)) + " Seconds";
     billboard.ApplyBillboardSequence(new BillboardSequence(message, true, true, true, true, true, true, 0, true, 'billboard.patterns.StartAtSameTime()', 'setTimeout(DisplayTryAgainButton, 800)', 0));
 }
 

--- a/SpeedReading/Script/Application.js
+++ b/SpeedReading/Script/Application.js
@@ -252,8 +252,6 @@ JetStream.onEnd(function (score) {
     // Constrain it to 0 - 2.5s
     score = Math.max(0, Math.min(2500, (9000 / score) - 1500));
 
-    console.log(score);
-
     JetStream.removeEndListeners();
     JetStream.clearPlans();
 

--- a/SpeedReading/Script/Performance.js
+++ b/SpeedReading/Script/Performance.js
@@ -124,13 +124,13 @@ function Performance() {
     this.StartTest = function () {
         this.testStarted = true;
         this.testRunning = true;
-        this.testStartTime = new Date();
+        this.testStartTime = performance.now();
     }
 
 
     this.hasBeen = function (interval) {
-        var now = new Date();
-        var totalTime = now.valueOf() - this.testStartTime.valueOf();
+        var now = performance.now();
+        var totalTime = now - this.testStartTime;
         return (totalTime >= interval);
     }
 
@@ -138,8 +138,8 @@ function Performance() {
 
     this.StopTest = function () {
         this.testRunning = false;
-        var now = new Date();
-        this.testDuration = now.valueOf() - this.testStartTime.valueOf();
+        var now = performance.now();
+        this.testDuration = now - this.testStartTime;
         if (displayEdgeMessage && alreadyDisplayedEdgeMessage) {
             // If we interupted with the "if you were using Edge" message, don't penalize the final time
             this.testDuration -= TIME_TO_DISPLAY_EDGE_MSG;


### PR DESCRIPTION
Changed the scoring to leverage performance.now(). Fixes the issue where final score didn't match actual elapsed time.
